### PR TITLE
Must pass 'attrs' parameter up to superclass render method 

### DIFF
--- a/django_password_strength/widgets.py
+++ b/django_password_strength/widgets.py
@@ -30,7 +30,7 @@ class PasswordStrengthInput(PasswordInput):
         except KeyError:
             self.attrs['class'] = 'password_strength'
 
-        return mark_safe( super(PasswordInput, self).render(name, value) + strength_markup )
+        return mark_safe( super(PasswordInput, self).render(name, value, attrs) + strength_markup )
 
     class Media:
         js = (
@@ -68,4 +68,4 @@ class PasswordConfirmationInput(PasswordInput):
         except KeyError:
             self.attrs['class'] = 'password_confirmation'
 
-        return mark_safe( super(PasswordInput, self).render(name, value) + confirmation_markup )
+        return mark_safe( super(PasswordInput, self).render(name, value, attrs) + confirmation_markup )


### PR DESCRIPTION
else id attribute may go missing.
This fixes #1
