### PR TITLE
Compatibility fix for newer Django versions

### DIFF
--- a/django_password_strength/widgets.py
+++ b/django_password_strength/widgets.py
@@ -8,7 +8,7 @@ class PasswordStrengthInput(PasswordInput):
     Form widget to show the user how strong his/her password is.
     """
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, **kwargs):
         strength_markup = """
         <div style="margin-top: 10px;">
             <div class="progress" style="margin-bottom: 10px;">
@@ -30,7 +30,7 @@ class PasswordStrengthInput(PasswordInput):
         except KeyError:
             self.attrs['class'] = 'password_strength'
 
-        return mark_safe( super(PasswordInput, self).render(name, value, attrs) + strength_markup )
+        return mark_safe( super(PasswordInput, self).render(name, value, **kwargs) + strength_markup )
 
     class Media:
         js = (
@@ -48,7 +48,7 @@ class PasswordConfirmationInput(PasswordInput):
         super(PasswordConfirmationInput, self).__init__(attrs, render_value)
         self.confirm_with=confirm_with
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, **kwargs):
         if self.confirm_with:
             self.attrs['data-confirm-with'] = 'id_%s' % self.confirm_with
 
@@ -68,4 +68,4 @@ class PasswordConfirmationInput(PasswordInput):
         except KeyError:
             self.attrs['class'] = 'password_confirmation'
 
-        return mark_safe( super(PasswordInput, self).render(name, value, attrs) + confirmation_markup )
+        return mark_safe( super(PasswordInput, self).render(name, value, **kwargs) + confirmation_markup )


### PR DESCRIPTION
Changed the widget .render() signatures to use **kwargs, to work with Django 2.1